### PR TITLE
Add branch switching to alternative .sharing.io repo branch

### DIFF
--- a/usr/local/bin/pair-init.sh
+++ b/usr/local/bin/pair-init.sh
@@ -75,6 +75,13 @@ fi
 if [ ! -d "/home/ii/.sharing.io" ]; then
     git clone "https://github.com/${SHARINGIO_PAIR_USER:-$USER}/.sharing.io" || \
         git clone https://github.com/sharingio/.sharing.io
+
+    if [ -z "${SHARINGIO_REPO_BRANCH}" ]; then
+        (
+            cd ~/.sharing.io
+            git switch "${SHARINGIO_REPO_BRANCH}" || true
+        )
+    fi
 fi
 
 . /home/ii/.sharing.io/sharingio-pair-preinit-script.sh


### PR DESCRIPTION
Given `SHARINGIO_REPO_BRANCH` is set, switch to a new target branch, in whatever _.sharing.io_ repo was cloned.